### PR TITLE
added consistency changes to website pages

### DIFF
--- a/_documentation/vscode.md
+++ b/_documentation/vscode.md
@@ -36,7 +36,7 @@ Before proceeding to setup VSCode, you will need to create an SSH config file on
   * This SSH configuration file is used to tell the SSH program about computers you can connect to, and to save settings for each computer.  This file may be empty right now, but you should add a new entry like this:
 
 ```
-Host pynq13
+Host pynq<number>
     Hostname pynq03.ee.byu.edu
     User byu
 ```
@@ -51,9 +51,9 @@ from the WSL terminal.  If you are using Mac or Linux, you don't need to create 
 
 ### Connecting via SSH 
   - Click the green button in the bottom left of VSCode, and select *Remote-SSH: Connect to Host..*
-  - If your SSH config file is set up correctly, you should now be given a list of the machines available in your SSH config file.  Select your *pynq13* board.
+  - If your SSH config file is set up correctly, you should now be given a list of the machines available in your SSH config file.  Select your *pynq\<number>* board.
   - A new VSCode window should pop up, and the VSCode server will be installed on your PYNQ board.  This can take a few minutes.  If an error pops up, try clicking *Retry* a few times.
-  - Once connected, the green status bar in the lower left corner should read *SSH: pynq13*
+  - Once connected, the green status bar in the lower left corner should read *SSH: pynq\<number>*
   - You can now click *File->Open Folder* and then select your *ecen427* repository folder that you cloned earlier.
 
 ### Re-Connecting

--- a/_other/submission.md
+++ b/_other/submission.md
@@ -11,10 +11,10 @@ Lab pass-offs will not be done in person.  Instead, you will create a *tag* in y
 
 Once you are done the lab, and want to submit, create a tag in your repo that the TAs can use to grade this lab, and then push like this:
 
-    git tag lab1_passoff
-    git push origin lab1_passoff
+    git tag lab1_submission
+    git push origin lab1_submission
 
-This tag will point to your most recent commit of whichever branch you are currently located on (so make sure all of your changes are committed before running this).  If you are not confident you did this correctly, you may want to go to a new directory (not in your repo) and run `git clone --branch lab1_passoff <repo_url>` to clone your tag and verify that it builds and runs correctly.
+This tag will point to your most recent commit of whichever branch you are currently located on (so make sure all of your changes are committed before running this).  If you are not confident you did this correctly, you may want to go to a new directory (not in your repo) and run `git clone --branch lab1_submission <repo_url>` to clone your tag and verify that it builds and runs correctly.
 
 If, after you create this tag, you want to change it (ie, re-submit your code), you can re-run the above commands and include the `--force` option to overwrite the tag, ie:
 


### PR DESCRIPTION
Just two proposed changes here. If either of them is in error, let me know and I will take them out.

**1.**
On the `Setup VSCode` page, I changed each instance of `pynq13` to `pynq<number>`. I am doing this under the assumption that pynq13 refers to the board number in the lab, and this will be different depending on the specific board being used.

**2.**
I made the `Lab Submission` page more consistent by changing the first block of commands to say `lab1_submission` instead of `lab1_passoff`. This is to match the rest of the page and avoid confusion.