### PR TITLE
Add req to print class_create in m1 of audio driver

### DIFF
--- a/_labs/audio_driver.md
+++ b/_labs/audio_driver.md
@@ -91,6 +91,7 @@ Your kernel driver needs to:
     * When a device is removed, undo all appropriate actions that were done when the device was added.
   * Add messages to print:
     * When your driver is loaded and unloaded.
+    * When your class is created.
     * When your device is added and removed.
     * The allocated major number of the driver and minor number of the device.
     * When you create your device using `device_create()`.


### PR DESCRIPTION
I think we should have the students print for class_create to grade/enforce this being done in init() instead of probe().